### PR TITLE
- Remove empty if block from simulation output receiver handler

### DIFF
--- a/src/js/services/SimulationControlService.ts
+++ b/src/js/services/SimulationControlService.ts
@@ -34,11 +34,6 @@ export class SimulationControlService {
   onSimulationOutputReceived(fn: (payload: SimulationOutputPayload) => void): StompSubscription {
     return this._stompClient.subscribe(this._simulationOutputTopic, (message: Message) => {
       const payload = JSON.parse(message.body);
-      if (payload.output) {
-        // TODO: payload.output uses single quotes for keys instead of double quotes which is invalid for JSON string
-        // Remove the replace() call when the backend creates a valid JSON string
-        // payload.output = JSON.parse(payload.output.replace(/'/g, '"'));
-      }
       fn(payload);
     });
   }

--- a/src/js/views/dropdown-menu/DropdownMenu.tsx
+++ b/src/js/views/dropdown-menu/DropdownMenu.tsx
@@ -35,6 +35,7 @@ export class DropdownMenu extends React.Component<Props, State> {
           className='app-dropdown-menu-toggler'
           title={this.state.currentLabel}
           onBlur={this._onClose}
+          tabIndex={0}
           onFocus={this._onOpen}>
           <span className='text'>{this.state.currentLabel}</span>
           <i className='app-icon'></i>

--- a/src/js/views/topology/LabelContainer.tsx
+++ b/src/js/views/topology/LabelContainer.tsx
@@ -78,9 +78,9 @@ export const LabelContainer = connect(mapStateToProps)(class LabelContainer exte
       if (!boundElementSelection.empty()) {
         const boundDatum = boundElementSelection.datum();
         topLevelGElementSelection.append('foreignObject')
-          .attr('width', 2000)
-          .attr('height', 2000)
-          // .style('width', '2000px')
+          .attr('width', 50000)
+          .attr('height', 50000)
+          .style('width', '50000px')
           .attr('x', boundDatum.rendering_x)
           .attr('y', boundDatum.rendering_y)
           .append('xhtml:div')


### PR DESCRIPTION
- Add tab index attribute to dropdown menu trigger because safari does not trigger onfocus event without it
- Fix the problem of labels getting truncated on firefox and safari

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gridappsd/viz/27)
<!-- Reviewable:end -->
